### PR TITLE
Encode with empty reservedURIComponentSet

### DIFF
--- a/query.js
+++ b/query.js
@@ -13,12 +13,16 @@ var appid =
 '8Q68TL-QA8W9GEXAA',
 ]
 
+var percentalize = str => 
+    encodeURIComponent(str)
+    .replace(/[-_.!~*'()]/g, char => '%' + char.charCodeAt(0).toString(16))
+
 var url = _ =>
 `
 https://lin2jing4-cors.herokuapp.com/
 http://api.wolframalpha.com/v2/query?
 &appid=${ appid[Date.now() % appid.length] }
-&input=${ location.hash = encodeURIComponent(input.value) }
+&input=${ location.hash = percentalize(input.value) }
 &podstate=Step-by-step solution
 &podstate=Step-by-step
 &podstate=Show all steps


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-uri-handling-functions
similar to the function fixedEncodeURIComponent for RFC3986
but encode also characters - _ . ~
https://github.com/microsoft/OCR-Form-Tools/blob/ad099565deb42cbc98caf077e95371eaf765432c/src/common/utils.ts#L355